### PR TITLE
Make back/forward buttons work on analyzer

### DIFF
--- a/dcp_sandbox/static/dcp_sandbox/js/TreeConstants.js
+++ b/dcp_sandbox/static/dcp_sandbox/js/TreeConstants.js
@@ -96,3 +96,6 @@ TreeConstants.SIGN_LEGEND = {"title": "Sign",
 
 // Alert div location.
 TreeConstants.ERROR_DIV = "#errorPlaceholder";
+
+// Query prefix for passing expressions in URL
+TreeConstants.URL_QUERY_PREFIX = "?expr=";

--- a/dcp_sandbox/static/dcp_sandbox/js/TreeDisplay.js
+++ b/dcp_sandbox/static/dcp_sandbox/js/TreeDisplay.js
@@ -73,17 +73,17 @@ TreeDisplay.createInputBox = function() {
     if (!TreeConstructor.promptActive) $('#inputBox').val(text);
     $('#inputBox').focus();
 
-    // Trigger reset if click away.
-    $('#inputBox').blur(function() {
-        // If the user didn't change the text, click again instead of
-        // parsing the objective again.
-        if (TreeDisplay.errorState && 
-            TreeDisplay.errorText == $('#inputBox').val()) {
-            setTimeout(function(){ $('#inputBox').focus(); }, 100);
-        } else { // User changed the text, so try to parse.
-            TreeDisplay.resetTree(id, textElement, text);
-        }
-    });
+    // // Trigger reset if click away.
+    // $('#inputBox').blur(function() {
+    //     // If the user didn't change the text, click again instead of
+    //     // parsing the objective again.
+    //     if (TreeDisplay.errorState && 
+    //         TreeDisplay.errorText == $('#inputBox').val()) {
+    //         setTimeout(function(){ $('#inputBox').focus(); }, 100);
+    //     } else { // User changed the text, so try to parse.
+    //         TreeDisplay.resetTree(id, textElement, text);
+    //     }
+    // });
 
     // Trigger reset if click enter.
     $('#inputBox').keypress(function(e) {
@@ -120,6 +120,8 @@ TreeDisplay.resetTree = function(id, textElement, text) {
     var modifiedText = $('#inputBox').val();
     var objective = TreeConstructor.loadObjective(id, modifiedText);
     // textElement.textContent = text;
+    var href = TreeConstants.URL_QUERY_PREFIX + encodeURIComponent(objective);
+    history.pushState(null, null, href);
     TreeConstructor.createParseTree(objective, id);
 }
 

--- a/dcp_sandbox/static/dcp_sandbox/js/analyzer.js
+++ b/dcp_sandbox/static/dcp_sandbox/js/analyzer.js
@@ -2,16 +2,36 @@
  * Analyzer Module
  * Handles page load for analyzer.
  */
+
+
+// Nodes in the parse tree can be edited.
+TreeConstructor.editable = true;
+
+function showTreeFromUrl() {
+    var query = location.search;
+    var len = TreeConstants.URL_QUERY_PREFIX.length
+
+    if (query.substr(0, len) == TreeConstants.URL_QUERY_PREFIX) {
+	var expression = decodeURIComponent(query.substr(len));
+	TreeConstructor.createParseTree(expression, TreeConstants.ROOT_TAG);
+    } else {
+	// Show the prompt
+	var promptTree = {
+            name: TreeConstants.PROMPT,
+            isPrompt: true,
+	};
+	TreeConstructor.leafLegendText = TreeConstants.PROMPT_LEAF_LEGEND;
+	TreeConstructor.promptActive = true;
+	TreeConstructor.processParseTree(promptTree);
+    }
+}
+
 (function($) {
+    $(window).on('popstate', function(event) {
+	showTreeFromUrl();
+    });
+
     $().ready(function(){
-        // Nodes in the parse tree can be edited.
-        TreeConstructor.editable = true;
-        // Show prompt.
-        var promptTree = {
-                         name: TreeConstants.PROMPT,
-                         isPrompt: true,
-                        };
-        TreeConstructor.leafLegendText = TreeConstants.PROMPT_LEAF_LEGEND;
-        TreeConstructor.processParseTree(promptTree);
+	showTreeFromUrl();
     });
 }(jQuery));


### PR DESCRIPTION
Hi Steven,

Two small usability suggestions:

1) Make back/forward button work
2) Dont change tree onblur

The first uses the HTML5 history API but the same thing could be accomplished by setting location.href with or without using a hash "#" parameter. 

The second was something I heard from students and experienced myself---its surprising when the page reloads when you switch windows (e.g. to look at the expression you are trying to type). I actually didn't realize that the expression is still editable on the tree page (until I started editing the code), so that actually helps with the problem somewhat. An alternative suggestion could be to make this more obvious, e.g. by calling focus() or something.

Tested on Chrome/Safari should work on any modern browser.

Cheers,
Matt
